### PR TITLE
Restrict scope to read only Patient and Observation resources of a patient to reflect actual scope and permissions Growth Chart SMART App requires

### DIFF
--- a/js/charts/body-mass-index-chart.js
+++ b/js/charts/body-mass-index-chart.js
@@ -35,6 +35,10 @@
 
         _get_dataPoints : function()
         {
+            if (GC.App.getPrimaryChartType() === "FENTON") {
+                Chart.prototype.noDataPoints = true;
+                return Chart.prototype._get_dataPoints.call( this, Chart.prototype.noDataPoints );
+            }
             return Chart.prototype._get_dataPoints.call( this, "bmi" );
         },
 

--- a/js/charts/chart.js
+++ b/js/charts/chart.js
@@ -2129,34 +2129,28 @@ Chart.prototype = {
             }, settings),
             set = this.pane.paper.set();
 
-        // The point shadow
-        if (!cfg.firstMonth) {
-            set.push(
-                this.pane.paper.circle(cx, cy + 0.5, cfg.firstMonth ? 6 : 5)
-                .attr({
-                    blur : Raphael.svg ? 1 : 0,
-                    fill : "#000"
-                }).addClass("point")
-            );
-        }
-
         set.push(
 
-            // The point white outline
-            this.pane.paper.circle(cx, cy, cfg.firstMonth ? 5 : 4).attr({
-                stroke : "#FFF",
-                "stroke-opacity": cfg.firstMonth ? 0.75 : 1,
-                "stroke-width" : cfg.firstMonth ? 4 : 2
-            }).addClass("point"),
+          // The shadow
+          this.pane.paper.circle(cx, cy + 0.5, 5).attr({
+              blur : Raphael.svg ? 1 : 0,
+              fill : "#000"
+          }).addClass("point"),
 
-            // The inner point
-            this.pane.paper.circle(cx, cy, 3).attr({
-                fill   : cfg.annotation ?
-                        this.settings.pointsColor :
-                        GC.Util.brighten(this.settings.pointsColor),
-                stroke : "none"/*,
-                title  : cfg.point ? cfg.point.value : "error"*/
-            }).addClass("point")
+          // The point white outline
+          this.pane.paper.circle(cx, cy, 4).attr({
+              stroke : "#FFF",
+              "stroke-opacity": 1,
+              "stroke-width" : 2
+          }).addClass("point"),
+
+          // The inner point
+          this.pane.paper.circle(cx, cy, 3).attr({
+              fill   : cfg.annotation ?
+                this.settings.pointsColor :
+                GC.Util.brighten(this.settings.pointsColor),
+              stroke : "none"
+          }).addClass("point")
         );
 
         this._nodes.push(set);

--- a/js/charts/chart.js
+++ b/js/charts/chart.js
@@ -34,6 +34,7 @@ Chart.prototype = {
     problemDataSet : "",
     isInLastRow    : true,
     title          : "Chart",
+    noDataPoints   : false,
 
     /**
      * Initializes the chart
@@ -705,9 +706,19 @@ Chart.prototype = {
      */
     getPatientDataPoints : function()
     {
+        if (GC.App.getPrimaryChartType() === "FENTON" && this.patientDataType === "bmi") {
+            this.noDataPoints = true;
+            return null;
+        }
         if ( this.patientDataType ) {
             var patient  = GC.App.getPatient(),
-                pointSet = new PointSet( patient.data[this.patientDataType], "agemos", "value" );
+                patientData = patient.data[this.patientDataType],
+                pointSet = new PointSet( patientData, "agemos", "value" );
+
+            // Check if data is defined
+            if (patientData) {
+                this.noDataPoints = patientData.length === 0;
+            }
 
             // Get only the points within the current time range
             pointSet.clip(
@@ -1263,10 +1274,11 @@ Chart.prototype = {
         this.drawVerticalGrid();
         this.drawTitle();
 
-        if ( !this.dataSet ) {
+        if ( this.noDataPoints && !this.dataSet ) {
+            this.drawNoData(GC.str("STR_158"));
+        } else if ( !this.dataSet ) {
             this.drawNoData(GC.str("STR_6046"));
         } else {
-
             if ( GC.chartSettings.drawChartOutlines ) {
                 this.drawOutlines();
             }
@@ -1290,7 +1302,7 @@ Chart.prototype = {
                 x2 = this.x + this.width - rShWidth;
 
             if ( len < 2 ) {
-                this.drawNoData(GC.str("STR_6046"));
+                this.drawNoData(GC.str("STR_158"));
             } else {
 
                 this.drawFillChartRegion(data);

--- a/js/gc-grid-view.js
+++ b/js/gc-grid-view.js
@@ -255,12 +255,7 @@
             //debugger;
             var age  = new GC.TimeInterval(patient.DOB).setMonths(data.agemos),
                 date = new XDate(patient.DOB.getTime()).addMonths(data.agemos),
-                sameDay = lastDate && lastDate.diffDays(date) < 1,
-                dateText = sameDay ?
-                    '<div style="text-align: center;font-size:20px">&bull;</div>' :
-                    date.toString(
-                        GC.chartSettings.dateFormat
-                    );//,
+                dateText = date.toString(GC.chartSettings.dateFormat);//,
                 // years,
                 // months,
                 // days;
@@ -268,16 +263,11 @@
             // Header - Date
             $('<th/>').append(
                 $('<div class="date"/>').html(dateText)
-            )
-            .appendTo(thr1);
+            ).appendTo(thr1);
 
             // Header - Age
-            $('<th/>')
-                .append( $('<div class=""/>').html(
-                    sameDay ?
-                    date.toString(GC.chartSettings.timeFormat) :
-                    age.toString(shortDateFormat)
-                )
+            $('<th/>').append(
+                $('<div class=""/>').html(age.toString(shortDateFormat))
             ).appendTo(thr2);
 
             $.each(scheme.header.rows, function(j, o) {

--- a/js/gc-grid-view.js
+++ b/js/gc-grid-view.js
@@ -95,7 +95,7 @@
     }
 
     function getBMI( entry ) {
-        if ( entry.hasOwnProperty("bmi") ) {
+        if ( entry.hasOwnProperty("bmi") && GC.App.getPrimaryChartType() !== "FENTON" ) {
             return GC.Util.format(entry.bmi, {
                 type       : "bmi",
                 unitMetric : "",

--- a/launch.html
+++ b/launch.html
@@ -8,7 +8,7 @@
     <script>
       FHIR.oauth2.authorize({
         "client_id": "growth_chart",
-        "scope":  "patient/*.read"
+        "scope":  "patient/Patient.read patient/Observation.read"
       });
     </script>
   </head>

--- a/load-fhir-data.js
+++ b/load-fhir-data.js
@@ -13,12 +13,24 @@ GC.get_data = function() {
         return false;
     }
 
+    function isValidObservationObj(obj){
+        if (obj.hasOwnProperty('status') && obj.status &&
+            (obj.status.toLowerCase() === 'final' || obj.status.toLowerCase() === 'amended') &&
+            obj.hasOwnProperty('valueQuantity') && obj.valueQuantity.hasOwnProperty('value') &&
+            obj.valueQuantity.hasOwnProperty('code')) {
+            return true;
+        }
+        return false;
+    }
+
     function processBoneAge(boneAgeValues, arr, units) {
         boneAgeValues && boneAgeValues.forEach(function(v){
-            arr.push({
-                date: v.effectiveDateTime,
-                boneAgeMos: units.any(v.valueQuantity)
-            })
+            if (isValidObservationObj(v)) {
+                arr.push({
+                    date: v.effectiveDateTime,
+                    boneAgeMos: units.any(v.valueQuantity)
+                })
+            }
         });
     }
 
@@ -92,10 +104,12 @@ GC.get_data = function() {
 
             function process(observationValues, toUnit, arr){
                 observationValues && observationValues.forEach(function(v){
-                    arr.push({
-                        agemos: months(v.effectiveDateTime, patient.birthDate),
-                        value: toUnit(v.valueQuantity)
-                    })
+                    if (isValidObservationObj(v)) {
+                        arr.push({
+                            agemos: months(v.effectiveDateTime, patient.birthDate),
+                            value: toUnit(v.valueQuantity)
+                        })
+                    }
                 });
             }
 


### PR DESCRIPTION
Currently, the Pediatric Growth Chart SMART app requests the scope `patient/*.read` when launching. While this works, the app is requesting far too broad permissions. The result of this is that the user may be suggested to grant the app far more FHIR resource scopes that are actually required of the app.

In order to more accurately reflect the scopes and permissions this app need to run, as well as to provide a good example for other SMART developers, this change requests just the two FHIR scopes this app needs to run: `patient/Patient.read` and `patient/Observation.read`
