### PR TITLE
Remove as much browser detection as possible to avoid future errors with this deprecated feature in jQuery and replace with checks to use defined property values instead

### DIFF
--- a/js/chart-pane.js
+++ b/js/chart-pane.js
@@ -286,9 +286,7 @@ ChartPane.prototype = {
             
             divider.addClass("active");
             
-            var root = $.browser.msie ?
-                     document.documentElement || document.body : 
-                     window,
+            var root = (document.documentElement || document.body) || window,
                 
                 left = $(inst.container).offset().left,
                 
@@ -372,9 +370,7 @@ ChartPane.prototype = {
                 return true;
             }
             
-            root = $.browser.msie ? 
-                document.documentElement || document.body : 
-                window;
+            root = (document.documentElement || document.body) || window;
             
             rect = inst.paper.rect()
                 .attr(GC.chartSettings.selectionRect)

--- a/js/gc-app.js
+++ b/js/gc-app.js
@@ -750,7 +750,6 @@
                 .toggleClass("no-transforms", !hasTransform)
                 .toggleClass("ie", $.browser.msie === true);
 
-            $.helperStyle("#dummy", {});
 
             if (PATIENT) {
                 BIRTH_XDATE = new XDate(PATIENT.birthdate);

--- a/js/util.js
+++ b/js/util.js
@@ -1787,12 +1787,12 @@ if ( !Array.prototype.indexOf ) {
             _helperStyle = $('<style type="text/css"/>').appendTo('head');
         }
         _helperStyle[0].disabled = false;
-        return _helperStyle[0][$.browser.msie ? 'styleSheet' : 'sheet'];
+        return _helperStyle[0]['sheet'] || _helperStyle[0]['styleSheet'];
     }
     
     $.helperStyle = function( selector, style ) {
         var s = getCssHelperStyle(), 
-            rules = s[$.browser.msie ? 'rules' : 'cssRules'],
+            rules = s['cssRules'] || s['rules'],
             handled = false;
         $.each(rules, function(i, rule) {
             if ( rule.selectorText.toLowerCase() === selector.toLowerCase() ) {


### PR DESCRIPTION
Currently, the SMART Growth Chart App has a few instances of using jQuery's browser detection to check if the user is using Internet Explorer, and will access browser-specific properties of objects if this is the case. This feature has been deprecated in versions of jQuery higher than that of which Growth Chart is using currently. [Microsoft has also decided](https://blogs.msdn.microsoft.com/ieinternals/2013/09/21/internet-explorer-11s-many-user-agent-strings/) starting with IE11 that this practice of development should cease. In fact, if the user is running IE11 and comes across a line such as `$.browser`, Microsoft has configured IE11 to actually return `mozilla` rather than `msie` (Microsoft Internet Explorer).

We can replace most of the browser detection in this project by checking for defined properties of objects instead. For example, instead of checking if the user is using IE and accessing an IE-specific property called `rules`, we just check to see if the property `rules` is defined, and if not use the `cssRules` property.

Additionally, there is a method-test line in the `gc-app.js` file that was left in the project that should be removed, as it is trying to dynamically add an empty list of css styles to a dummy element.