### PR TITLE
Adjust potential height based on mid-parental height based on gender

### DIFF
--- a/js/gc-smart-data.js
+++ b/js/gc-smart-data.js
@@ -461,7 +461,7 @@ window.GC = window.GC || {};
             this.familyHistory.mother.height &&
             this.familyHistory.father.isBio  && 
             this.familyHistory.mother.isBio) {
-            this.midParentalHeight = GC.Util.round((this.familyHistory.father.height + this.familyHistory.mother.height) / 2);
+            this.midParentalHeight = this.getMidParentalHeight().height;
         } else {
             this.midParentalHeight = null;
         }
@@ -842,7 +842,11 @@ window.GC = window.GC || {};
             !this.familyHistory.mother.isBio) {
             return null;
         }
-        var midHeight = GC.Util.round((this.familyHistory.father.height + this.familyHistory.mother.height) / 2);
+        var midHeight
+        if (this.gender === "male")
+            midHeight = GC.Util.round((this.familyHistory.father.height + this.familyHistory.mother.height + 13) / 2);
+        else
+            midHeight = GC.Util.round((this.familyHistory.father.height + this.familyHistory.mother.height - 13) / 2);
         
         var dataSet    = GC.DATA_SETS.CDC_STATURE;
         var data       = dataSet.data[this.gender];


### PR DESCRIPTION
Previously, the calculation was just taking an average, but it should be adjusted for gender.

From:  http://www.uptodate.com/contents/calculator-prediction-of-childs-target-height-based-on-midparental-height

For both girls and boys, 8.5 cm on either side of this calculated value (target height) represents the 3rd to 97th percentiles for anticipated adult height.  
This height prediction is based on the sex-adjusted midparental height and the methods below.  
For girls: subtract 13 cm from the father's height and average with the mother's height.  
For boys: add 13 cm to the mother's height and average with the father's height.  
13 cm is the average difference in height of women and men.  
The height percentile reflects the "height potential" output as compared with adults of the same gender. It is based on a lookup of height percentiles for the appropriate gender at age 19.99 years, using the growth reference charts prepared by the Centers for Disease Control/National Center for Health Statistics (CDC/NCHS).