### PR TITLE
Add additional settings in the GC config file for further app customization

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1545,6 +1545,12 @@ span.title {
 	right: -36px;
 	background: url(../img/tab-sprite.png) -20px -42px no-repeat;
 }
+
+/* Override the padding for the GC tab to rid the space of the hidden compare button */
+#the-tab.hide-compare-button {
+	padding: 11px 0 1px 0;
+}
+
 .view-table #the-tab .disable-overlay,
 .view-parental #the-tab .disable-overlay {
 	display: block;

--- a/index.html
+++ b/index.html
@@ -98,14 +98,14 @@
                         <tr>
                             <th data-translatecontent="STR_3007"></th>
                             <td><span class="vertical-divider"></span></td>
-                            <td align="right" data-translatecontent="STR_3008"></td>
+                            <td class="parent-labels" align="right" data-translatecontent="STR_3008"></td>
                             <td style="white-space:nowrap">
                             <input type="text" name="mother-height" style="width:7em" />
-                            <label style="white-space:nowrap;margin-right:-2em">
+                            <label style="white-space:nowrap">
                                 <input type="checkbox" name="bio-mother" >
                                 <span data-translatecontent="STR_3009"></span>
                                 </label></td>
-                            <td align="right" data-translatecontent="STR_3010"></td>
+                            <td class="parent-labels" align="right" data-translatecontent="STR_3010"></td>
                             <td colspan="2" style="white-space:nowrap">
                             <input type="text" name="fader-height" style="width:7em" />
                             <label style="white-space:nowrap">
@@ -123,107 +123,109 @@
                         <tr class="empty-row">
                             <td colspan="12"></td>
                         </tr>
-                        <tr>
-                            <th class="prefs-header"><div class="icon" id="system-settings-icon"></div><span data-translatecontent="STR_3014"></span></th>
-                            <td><span class="vertical-divider"></span></td>
-                            <td></td>
-                            <td>
-                            <input type="button" data-translateattr="value=STR_3015" onClick="GC.App.editSettings()" />
-                            </td>
-                            <td colspan="2">
-                                <input type="button" data-translateattr="value=STR_3016" onClick="GC.App.aboutAppDialog()" />
-                                <!--label>
-                                    <input type="checkbox" id="edit-enabled" checked="checked" />
-                                    Enable patient editing 
-                                </label-->
-                            </td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <th data-translatecontent="STR_3017"></th>
-                            <td><span class="vertical-divider"></span></td>
-                            <td colspan="4" style="white-space:nowrap; text-align:right">
-                            <input class="toggle-button" type="hidden" name="metrics" value="metric" data-value1="metric" data-value2="eng" data-label1="kg/cm" data-label2="lb/ft" />
-                            &nbsp;<span class="vertical-divider"></span>&nbsp;
-                            <input class="toggle-button" type="hidden" name="pctz" value="pct" data-value1="pct" data-value2="z" data-label1="%" data-label2="Z" />
-                            &nbsp;<span class="vertical-divider"></span>&nbsp;
-                            <span class="language-selector"></span>
-                            <!--input class="toggle-button" type="hidden" name="language" value="en" data-value1="en" data-value2="es" data-label1="English" data-label2="Spanish" /-->
-                            </td>
-                            <td align="right" data-translatecontent="STR_3018"></td>
-                            <td>
-                            <select name="roundPrecision.velocity.std" style="width:7em">
-                                <option value="year" data-translatecontent="STR_3020"></option>
-                                <option value="month" data-translatecontent="STR_3021"></option>
-                                <option value="week" data-translatecontent="STR_3022"></option>
-                                <option value="day" data-translatecontent="STR_3023"></option>
-                                <option value="auto" data-translatecontent="STR_3057"></option>
-                            </select></td>
-                            <td align="right" style="white-space: nowrap;" data-translatecontent="STR_3019" ></td>
-                            <td>
-                            <select name="roundPrecision.velocity.nicu" style="width:7em">
-                                <option value="year" data-translatecontent="STR_3024"></option>
-                                <option value="month" data-translatecontent="STR_3025"></option>
-                                <option value="week" data-translatecontent="STR_3026"></option>
-                                <option value="day" data-translatecontent="STR_3027"></option>
-                                <option value="auto" data-translatecontent="STR_3058"></option>
-                            </select></td>
-                            <td>&nbsp;</td>
-                            <td></td>
-                        </tr>
-                        <tr>
-                            <th data-translatecontent="STR_3028"></th>
-                            <td><span class="vertical-divider"></span></td>
-                            <td align="right" data-translatecontent="STR_3029"></td>
-                            <td>
-                                <select name="gest-correction-type">
-                                    <option value="fixed" data-translatecontent="STR_3030"></option>
-                                    <option value="declining" data-translatecontent="STR_3031"></option>
-                                    <option value="both" data-translatecontent="STR_3032"></option>
-                                    <option value="none" data-translatecontent="STR_3033"></option>
-                                </select>
-                            </td>
-                            <td align="right" style="white-space:nowrap" data-translatecontent="STR_3034"></td>
-                            <td>
-                                <input name="gest-correction-treshold" type="text" style="width:10em;" data-translateattr="value=STR_3035"/>
-                            </td>
-                            <td style="white-space:nowrap" colspan="2" data-translatecontent="STR_3036"></td>
-                            <td>&nbsp;</td>
-                            <td>&nbsp;</td>
-                            <td>&nbsp;</td>
-                            <td></td>
-                        </tr>
-                        <tr class="last">
-                            <th data-translatecontent="STR_3037"></th>
-                            <td><span class="vertical-divider"></span></td>
-                            <td align="right" data-translatecontent="STR_3038"></td>
-                            <td>
-                            <select name="aspectRatio" title="Height-To-Width Ratio">
-                                <option value="0.8">1:1.25</option>
-                                <option value="0.625">1:1.6</option>
-                                <option value="1" data-translatecontent="STR_3059"></option>
-                                <option value="0.5">1:2</option>
-                                <option value="0.6666666666666667">2:3</option>
-                                <option value="0.75">3:4</option>
-                                <option value="0.6">3:5</option>
-                                <option value="0.375">9:16</option>
-                                <option value="0" data-translatecontent="STR_3039"></option>
-                            </select></td>
-                            <td align="right" data-translatecontent="STR_3040"></td>
-                            <td>
-                            <input name="fontSize" type="text" />
-                            </td>
-                            <td align="right" data-translatecontent="STR_3041"></td>
-                            <td colspan="2"><select name="color-preset"></select></td>
-                            <td>&nbsp;</td>
-                            <td>&nbsp;</td>
-                            <td></td>
-                        </tr>
+                        <tbody class="gc-app-preferences">
+                            <tr>
+                                <th class="prefs-header"><div class="icon" id="system-settings-icon"></div><span data-translatecontent="STR_3014"></span></th>
+                                <td><span class="vertical-divider"></span></td>
+                                <td></td>
+                                <td>
+                                <input type="button" data-translateattr="value=STR_3015" onClick="GC.App.editSettings()" />
+                                </td>
+                                <td colspan="2">
+                                    <input type="button" data-translateattr="value=STR_3016" onClick="GC.App.aboutAppDialog()" />
+                                    <!--label>
+                                        <input type="checkbox" id="edit-enabled" checked="checked" />
+                                        Enable patient editing
+                                    </label-->
+                                </td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <th data-translatecontent="STR_3017"></th>
+                                <td><span class="vertical-divider"></span></td>
+                                <td colspan="4" style="white-space:nowrap; text-align:right">
+                                <input class="toggle-button" type="hidden" name="metrics" value="metric" data-value1="metric" data-value2="eng" data-label1="kg/cm" data-label2="lb/ft" />
+                                &nbsp;<span class="vertical-divider"></span>&nbsp;
+                                <input class="toggle-button" type="hidden" name="pctz" value="pct" data-value1="pct" data-value2="z" data-label1="%" data-label2="Z" />
+                                &nbsp;<span class="vertical-divider"></span>&nbsp;
+                                <span class="language-selector"></span>
+                                <!--input class="toggle-button" type="hidden" name="language" value="en" data-value1="en" data-value2="es" data-label1="English" data-label2="Spanish" /-->
+                                </td>
+                                <td align="right" data-translatecontent="STR_3018"></td>
+                                <td>
+                                <select name="roundPrecision.velocity.std" style="width:7em">
+                                    <option value="year" data-translatecontent="STR_3020"></option>
+                                    <option value="month" data-translatecontent="STR_3021"></option>
+                                    <option value="week" data-translatecontent="STR_3022"></option>
+                                    <option value="day" data-translatecontent="STR_3023"></option>
+                                    <option value="auto" data-translatecontent="STR_3057"></option>
+                                </select></td>
+                                <td align="right" style="white-space: nowrap;" data-translatecontent="STR_3019" ></td>
+                                <td>
+                                <select name="roundPrecision.velocity.nicu" style="width:7em">
+                                    <option value="year" data-translatecontent="STR_3024"></option>
+                                    <option value="month" data-translatecontent="STR_3025"></option>
+                                    <option value="week" data-translatecontent="STR_3026"></option>
+                                    <option value="day" data-translatecontent="STR_3027"></option>
+                                    <option value="auto" data-translatecontent="STR_3058"></option>
+                                </select></td>
+                                <td>&nbsp;</td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <th data-translatecontent="STR_3028"></th>
+                                <td><span class="vertical-divider"></span></td>
+                                <td align="right" data-translatecontent="STR_3029"></td>
+                                <td>
+                                    <select name="gest-correction-type">
+                                        <option value="fixed" data-translatecontent="STR_3030"></option>
+                                        <option value="declining" data-translatecontent="STR_3031"></option>
+                                        <option value="both" data-translatecontent="STR_3032"></option>
+                                        <option value="none" data-translatecontent="STR_3033"></option>
+                                    </select>
+                                </td>
+                                <td align="right" style="white-space:nowrap" data-translatecontent="STR_3034"></td>
+                                <td>
+                                    <input name="gest-correction-treshold" type="text" style="width:10em;" data-translateattr="value=STR_3035"/>
+                                </td>
+                                <td style="white-space:nowrap" colspan="2" data-translatecontent="STR_3036"></td>
+                                <td>&nbsp;</td>
+                                <td>&nbsp;</td>
+                                <td>&nbsp;</td>
+                                <td></td>
+                            </tr>
+                            <tr class="last">
+                                <th data-translatecontent="STR_3037"></th>
+                                <td><span class="vertical-divider"></span></td>
+                                <td align="right" data-translatecontent="STR_3038"></td>
+                                <td>
+                                <select name="aspectRatio" title="Height-To-Width Ratio">
+                                    <option value="0.8">1:1.25</option>
+                                    <option value="0.625">1:1.6</option>
+                                    <option value="1" data-translatecontent="STR_3059"></option>
+                                    <option value="0.5">1:2</option>
+                                    <option value="0.6666666666666667">2:3</option>
+                                    <option value="0.75">3:4</option>
+                                    <option value="0.6">3:5</option>
+                                    <option value="0.375">9:16</option>
+                                    <option value="0" data-translatecontent="STR_3039"></option>
+                                </select></td>
+                                <td align="right" data-translatecontent="STR_3040"></td>
+                                <td>
+                                <input name="fontSize" type="text" />
+                                </td>
+                                <td align="right" data-translatecontent="STR_3041"></td>
+                                <td colspan="2"><select name="color-preset"></select></td>
+                                <td>&nbsp;</td>
+                                <td>&nbsp;</td>
+                                <td></td>
+                            </tr>
+                        </tbody>
                     </table>
                 </div>
                 

--- a/js/gc-app.js
+++ b/js/gc-app.js
@@ -308,17 +308,16 @@
     }
     
     function togglePatientEditable(bEditable) {
+        $('[name="DOB"]').datepicker( bEditable ? "enable" : "disable");
+        $('[name="EDD"]').datepicker( bEditable ? "enable" : "disable");
+        $(".add-entry").toggleClass("ui-state-disabled", !bEditable);
+    }
+    
+    function toggleParentEditable(bEditable) {
         $('[name="fader-height"]').stepInput( bEditable ? "enable" : "disable");
         $('[name="mother-height"]').stepInput( bEditable ? "enable" : "disable");
         $('[name="bio-father"]').prop("disabled", !bEditable);
         $('[name="bio-mother"]').prop("disabled", !bEditable);
-        $('[name="DOB"]').datepicker( bEditable ? "enable" : "disable");
-        $('[name="EDD"]').datepicker( bEditable ? "enable" : "disable");
-        //$(".add-entry").toggleClass("ui-state-disabled", !bEditable);
-    }
-    
-    function togglePatientDataEditable(bEditable) {
-        $(".add-entry").toggleClass("ui-state-disabled", !bEditable);
     }
 
     NS.App.DEBUG_MODE = DEBUG_MODE;
@@ -919,6 +918,28 @@
                     $("#view-parental")["hide"]();
                 }
 
+                // hide app preferences
+                if ( GC.Preferences._data.hideAppPreferences ) {
+                    $('.gc-app-preferences')["hide"]();
+                    $('.parent-labels').css({
+                       padding: "0.4em 4px 0.4em 16px"
+                    });
+                }
+
+                // hide growth chart comparing feature
+                if ( GC.Preferences._data.hideGCComparison ) {
+                    $('#tab-btn-right')["hide"]();
+                    $('#the-tab').addClass('hide-compare-button');
+                }
+
+                // hide add data button
+                if ( GC.Preferences._data.hideAddData ) {
+                    $('#info-bar').css({
+                       "padding-right": "10px"
+                    });
+                    $('.add-entry')["hide"]();
+                }
+
                 setStageHeight();
 
                 draw(type);
@@ -1431,8 +1452,8 @@
 
             GC.Preferences.bind("set:dateFormat", showLastRecOrSelection);
             
-            togglePatientEditable(GC.chartSettings.patientFamilyHistoryEditable);
-            togglePatientDataEditable(GC._isPatientDataEditable);
+            togglePatientEditable(GC.chartSettings.patientDataEditable);
+            toggleParentEditable(GC.chartSettings.patientFamilyHistoryEditable);
             
             done();
         }

--- a/js/gc-chart-config.js
+++ b/js/gc-chart-config.js
@@ -24,7 +24,7 @@ window.GC = window.GC || {};
     // =========================================================================
     var readOnlySettings = {
         
-        fileRevision : 202,
+        fileRevision : 203,
         
         // See the toString method for the rendering template
         version : {
@@ -64,6 +64,9 @@ window.GC = window.GC || {};
     var settings = {
         isParentTabShown : true,
         hidePatientHeader: true,
+        hideAppPreferences: false,
+        hideGCComparison: false,
+        hideAddData: false,
         defaultChart : "CDC", // 2+ years
         defaultBabyChart : "WHO", // 0 - 2 years
         defaultPrematureChart : "FENTON", // premature


### PR DESCRIPTION
Currently, anyone who customizes the SMART Growth Chart App can choose to enable editing of parent heights in the header, make the parent tab hidden/shown, as well as hide the patient header if necessary, among other various settings. With this system of creating a separate file for app configuration comes the opportunity to possibly add other settings that affect the app with hiding and displaying certain elements. 

Specifically, some other settings that someone modifying this app may want is the ability to hide/show the following:
- App Preferences (under the gear icon)
- Comparing Growth Chart types (the + button)
- Add Data functionality

We can set these as separate boolean flags such as many of the other settings already in the config file, and can hide the above functionality if necessary. 
