### PR TITLE
Hide any BMI data that displays when the user is viewing the Fenton Growth Chart. Place message on BMI chart to say No Data when viewing under the Fenton dataset.

### DIFF
--- a/js/charts/body-mass-index-chart.js
+++ b/js/charts/body-mass-index-chart.js
@@ -35,6 +35,10 @@
 
         _get_dataPoints : function()
         {
+            if (GC.App.getPrimaryChartType() === "FENTON") {
+                Chart.prototype.noDataPoints = true;
+                return Chart.prototype._get_dataPoints.call( this, Chart.prototype.noDataPoints );
+            }
             return Chart.prototype._get_dataPoints.call( this, "bmi" );
         },
 

--- a/js/charts/chart.js
+++ b/js/charts/chart.js
@@ -34,6 +34,7 @@ Chart.prototype = {
     problemDataSet : "",
     isInLastRow    : true,
     title          : "Chart",
+    noDataPoints   : false,
 
     /**
      * Initializes the chart
@@ -705,9 +706,19 @@ Chart.prototype = {
      */
     getPatientDataPoints : function()
     {
+        if (GC.App.getPrimaryChartType() === "FENTON" && this.patientDataType === "bmi") {
+            this.noDataPoints = true;
+            return null;
+        }
         if ( this.patientDataType ) {
             var patient  = GC.App.getPatient(),
-                pointSet = new PointSet( patient.data[this.patientDataType], "agemos", "value" );
+                patientData = patient.data[this.patientDataType],
+                pointSet = new PointSet( patientData, "agemos", "value" );
+
+            // Check if data is defined
+            if (patientData) {
+                this.noDataPoints = patientData.length === 0;
+            }
 
             // Get only the points within the current time range
             pointSet.clip(
@@ -1263,10 +1274,11 @@ Chart.prototype = {
         this.drawVerticalGrid();
         this.drawTitle();
 
-        if ( !this.dataSet ) {
+        if ( this.noDataPoints && !this.dataSet ) {
+            this.drawNoData(GC.str("STR_158"));
+        } else if ( !this.dataSet ) {
             this.drawNoData(GC.str("STR_6046"));
         } else {
-
             if ( GC.chartSettings.drawChartOutlines ) {
                 this.drawOutlines();
             }
@@ -1290,7 +1302,7 @@ Chart.prototype = {
                 x2 = this.x + this.width - rShWidth;
 
             if ( len < 2 ) {
-                this.drawNoData(GC.str("STR_6046"));
+                this.drawNoData(GC.str("STR_158"));
             } else {
 
                 this.drawFillChartRegion(data);

--- a/js/gc-grid-view.js
+++ b/js/gc-grid-view.js
@@ -95,7 +95,7 @@
     }
 
     function getBMI( entry ) {
-        if ( entry.hasOwnProperty("bmi") ) {
+        if ( entry.hasOwnProperty("bmi") && GC.App.getPrimaryChartType() !== "FENTON" ) {
             return GC.Util.format(entry.bmi, {
                 type       : "bmi",
                 unitMetric : "",


### PR DESCRIPTION
Currently, any data pertaining to a patient's BMI is pulled into the Growth Chart application and displayed on all BMI graphs and charts, for all datasets. Though, for the Fenton dataset, BMI is not applicable for patients in that setting. This is also indicated by the "No curves data" placeholder on the BMI chart under the Fenton dataset.

To better convey to the user that BMI is not applicable under the Fenton dataset, we could replace the "No curves data" with simply "No data", and hide any BMI data points on the graph view. When another dataset is selected, the BMI data charted for the patient would return.