### PR TITLE
Fix for Growth Chart’s print functionality being extremely slow in IE.

### DIFF
--- a/css/gc-pview-print.css
+++ b/css/gc-pview-print.css
@@ -1,0 +1,17 @@
+#vitals {
+    border-color: transparent;
+}
+
+#PatientHeader, #PredictedHeightHeader {
+    background-color: transparent;
+    color: #666;
+}
+
+#PaperPredictedHeight {
+    overflow: inherit;
+}
+
+#RightPaper {
+    transform-origin: left;
+    transform: scale(.8,.9);
+}

--- a/css/print.css
+++ b/css/print.css
@@ -66,18 +66,23 @@ h1 {
     margin: 0;
 }
 
+#container {
+    display: inline-block;
+    text-align: left;
+    margin: auto;
+}
+
 .frame {
     border: 1px solid #666;
     display: inline-block;
     text-align: left;
-    width: 1000px;
+    margin:auto;
 }
 
 #header {
     background: transparent;
     padding: 0 10px 10px;
     text-align: left;
-    width: 1000px;
     margin: auto;
 }
 
@@ -110,7 +115,7 @@ svg {
 #view-parental,
 #view-table,
 .timeline {
-    display: none;
+    display: block;
 }
 
 .view-clinical #view-clinical,

--- a/gc-print.html
+++ b/gc-print.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Growth Chart Print Preview</title>
+    <link rel="stylesheet" type="text/css" href="css/gc-pview.css" />
+    <link rel="stylesheet" type="text/css" href="css/print.css" />
+    <link rel="stylesheet" type="text/css" href="css/gc-pview-print.css" />
+</head>
+<body>
+<div id="print-toolbar">
+    <a href="javascript:window.print();" class="print-link">
+        <img src="img/print.png" alt="" />
+        <span data-translatecontent="STR_6020"></span>
+    </a>
+</div>
+<div id="container">
+    <div id="header">
+        <h1 class="patient-name" data-translatecontent="STR_6021">Patient`s name</h1>
+        <label class="gender-color" data-translatecontent="STR_155"></label> <span class="patient-gender title"></span>
+        <label class="gender-color" data-translatecontent="STR_157"></label> <span class="patient-birth title"></span>
+        <label class="gender-color" data-translatecontent="STR_156"></label> <span class="patient-age title"></span>
+        <span id="weekerID" class="weeker" style="display:none;">
+            <label class="gender-color">{</label>
+            <span id="weekerValue" class="value title" style="margin-right: 0"></span>
+            <label class="gender-color">}</label>&nbsp;&nbsp;
+        </span>
+        <span id="correctedAgeID" style="display: none;">
+            <label class="gender-color" data-translatecontent="STR_6022"></label>
+            <span id="corrected-age" class="title"></span>
+        </span>
+        <span id="today"></span>
+    </div>
+    <div class="frame">
+        <div id="timeline-top"></div>
+        <div id="stage">
+            <div id="view-table" class="tab-panel"></div>
+        </div>
+        <div id="timeline-bottom"></div>
+    </div>
+</div>
+<script>
+    /**
+     * This call to the function on the opener is for indicating that the UI is ready to accept updates from the GC main
+     * window.
+     */
+    window.opener.printFunctionalityLoaded(window);
+</script>
+</body>
+</html>

--- a/js/gc-grid-view.js
+++ b/js/gc-grid-view.js
@@ -480,7 +480,9 @@
     }
 
     function renderTableViewForPrint(container) {
-        $(container).empty();
+        if (container) {
+            $(container).empty();
+        }
 
         var printScheme = [
             {
@@ -665,7 +667,11 @@
 
         html[j++] = '</table>';
 
-        $(container).html(html.join(""));
+        if (container){
+            $(container).html(html.join(""));
+        } else {
+            return html;
+        }
     }
 
     function getVelocityUnits(baseUnits) {
@@ -884,6 +890,10 @@
             }
         },
         selectByAge : PRINT_MODE ? $.noop : selectByAge
+    };
+
+    NS.TableViewForPrint = function () {
+        return renderTableViewForPrint();
     };
 
     $(function() {


### PR DESCRIPTION
Issue : The open source version of growth chart pops out a window for the print functionality. When the application is run in IE, launching the print window opens up the pop-up but the content is rendered extremely slow. This results in the user staring at a blank page for several seconds and sometimes minutes before any UI gets rendered on the screen. This gives the user an impression that the UI is stuck.
More Info on this Issue : https://github.com/smart-on-fhir/growth-chart-app/issues/26

Fix : This PR fixes the slowness issue. The fix involves loading content on the popup window from the main growth chart window.

Changes :
A new gc-print.html page is loaded when we click on the Print Icon on Main window.
The Main GC window uses the rendered "Graph" and "Parent" views from the main window to be shown on the print popup based on the selection on the main window. If "Table" view is selected on the main window we redraw the table in a vertical orientation on the print popup.

**Printing Considerations/Instructions : **
The user will need to print in landscape mode for Graph and Parent views where as portrait mode can be used for Table view.
