### PR TITLE
Fix for Growth Chart not displaying Bone Age in the Table view issue.

### DIFF
--- a/js/gc-smart-data.js
+++ b/js/gc-smart-data.js
@@ -336,6 +336,9 @@ window.GC = window.GC || {};
 
         if (boneAgeList && boneAgeList.length) {
             $.each(boneAgeList, function(i, o) {
+                if (o.hasOwnProperty("boneAgeMos") && o.hasOwnProperty("date")) {
+                    o = new SmartBoneage(o.date, o.boneAgeMos);
+                }
                 if (o instanceof SmartBoneage) {
                     patient.boneAge.push(o.toGCBoneage(patient));
                 } else {


### PR DESCRIPTION
Issue : The open source version of growth chart does not display the Bone Age received in the observations on the Table View of the app.

More Info on this Issue : smart-on-fhir#27
Fix : This PR fixes the display to consume the observation received. The issue was because the observation was never used while building the SmartBoneage object in the gc-smart-data.js

Changes :
The fix now checks if the observation has the properties "boneAgeMos" and "date" and creates a SmartBoneage object to be used later in the app. This fixed the display in the Table View.
